### PR TITLE
IPTV-3238 Add cache headers to responses

### DIFF
--- a/src/common/middleware/cacheControl.js
+++ b/src/common/middleware/cacheControl.js
@@ -1,0 +1,6 @@
+const maxAgeInSeconds = 300
+
+module.exports = (req, res, next) => {
+  res.set('Cache-Control', `public, max-age=${maxAgeInSeconds}`)
+  next()
+}

--- a/src/router.js
+++ b/src/router.js
@@ -6,6 +6,7 @@ const logger = require('./common/logger')
 
 const userAgent = require('./device-identification/middleware/user-agent')
 const whoami = require('./device-identification/middleware/whoami')
+const cacheControl = require('./common/middleware/cacheControl')
 
 const { name, version } = require('../package')
 
@@ -21,6 +22,8 @@ router.get('/status', (req, res) => {
 router.get('/version', (req, res) => {
   res.json({ version, name })
 })
+
+router.use(cacheControl)
 
 router.get('/identify/ua/:ua/:format', userAgent)
 router.get('/identify/whoami/:whoami/:format', whoami)

--- a/test/integration/identify-spec.js
+++ b/test/integration/identify-spec.js
@@ -26,6 +26,15 @@ describe('Identify', () => {
           done()
         })
     })
+    it('Contains the expected cache headers', (done) => {
+      request.get('/identify/ua/smarttv_AFTS_Build_565189620_Chromium_34.0.1847.114/json')
+        .end((err, res) => {
+          if (err) throw err
+          expect(res.status).toBe(200)
+          expect(res.headers['cache-control']).toEqual('public, max-age=300')
+          done()
+        })
+    })
   })
   describe('if given an invalid user agent', () => {
     it('Returns an error message', (done) => {
@@ -48,6 +57,15 @@ describe('Identify', () => {
           expect(res.status).toBe(200)
           expect(res.body.brand).toEqual('sony')
           expect(res.body.model).toEqual('hbbtv_2013')
+          done()
+        })
+    })
+    it('Contains the expected cache headers', (done) => {
+      request.get('/identify/whoami/SNYLCD035/json')
+        .end((err, res) => {
+          if (err) throw err
+          expect(res.status).toBe(200)
+          expect(res.headers['cache-control']).toEqual('public, max-age=300')
           done()
         })
     })


### PR DESCRIPTION
Adds a cache control header for 5 minutes (public) for all endpoints except `/status` and `/version`