### PR TITLE
Move all files, not just .conf files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "spec": {
     "post": [
-      "mv /usr/lib/matterhorn/pipeline/bake-scripts/apache/*.conf /etc/httpd/conf.d/",
+      "mv /usr/lib/matterhorn/pipeline/bake-scripts/apache/* /etc/httpd/conf.d/",
       "mv /usr/lib/matterhorn/pipeline/bake-scripts /etc/bake-scripts/matterhorn"
     ],
     "executable": [


### PR DESCRIPTION
Files without .conf are now present in the Apache bake-scripts, and need to be moved as part of the post install.