### PR TITLE
remove logic that tried to include version in rpm release string

### DIFF
--- a/scripts/npm/prerelease.sh
+++ b/scripts/npm/prerelease.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION=$(node -e "console.log(require('./package.json').version)")
-speculate --release $VERSION_`git rev-parse --short HEAD`
+speculate --release `git rev-parse --short HEAD`
 mkdir -p /root/rpmbuild/SOURCES/
 cp SOURCES/matterhorn.tar.gz /root/rpmbuild/SOURCES/matterhorn.tar.gz
 rpmbuild -ba SPECS/matterhorn.spec


### PR DESCRIPTION
It didn't work because it was seeing the variable as `$VERSION_`. It would have needed to be `${VERSION}_`. This PR shouldn't change any behaviour.