### PR TITLE
BADHORSE-42 fetch tvp-whoami from the new location

### DIFF
--- a/ci/infrastructure/stacks/templates/matterhorn.json
+++ b/ci/infrastructure/stacks/templates/matterhorn.json
@@ -30,7 +30,10 @@
                   "s3:GetObject"
                 ],
                 "Effect": "Allow",
-                "Resource": "arn:aws:s3:::test-device-identification-data-bucket-1u0gmv027tr5a/*"
+                "Resource": [
+                  "arn:aws:s3:::test-device-identification-data-bucket-1u0gmv027tr5a/*",
+                  "arn:aws:s3:::test-tvp-whoami-bucket-1npt44dhbyabk/*"
+                ]
               }
             }
           }

--- a/src/device-identification/middleware/whoami.js
+++ b/src/device-identification/middleware/whoami.js
@@ -27,11 +27,14 @@ function identifyDeviceByWhoami (req, res, next) {
   }
 
   return whoamiModel.fetch()
-    .then((allDevices) => {
+    .then((devices) => {
+      const shouldUseTestData = process.env.ENVIRONMENT === 'local' || req.query.testMode
+      const data = shouldUseTestData ? devices.test : devices.live
+
       const matchPattern = item => new RegExp(item.who_am_i_pattern).test(whoami)
       const filterMatches = R.filter(matchPattern)
       const firstMatch = R.head
-      const device = R.compose(firstMatch, filterMatches)(allDevices)
+      const device = R.compose(firstMatch, filterMatches)(data)
       if (device) {
         deviceCache[whoami] = device
         return sendResponse(res, deviceCache[whoami])

--- a/src/device-identification/models/whoami-data.js
+++ b/src/device-identification/models/whoami-data.js
@@ -1,18 +1,41 @@
-const request = require('../../common/request-promise')
+const AWS = require('aws-sdk')
+
+const s3 = new AWS.S3({ region: 'eu-west-1' })
+
 const updateIntervalMs = 5 * 60 * 1000 // 5 minutes in milliseconds
 
 let devices
 
-function makeRequest () {
-  return request.get('https://connected-tv.files.bbci.co.uk/tvp-whoami/data/json')
-}
+async function updateDeviceData () {
+  let testData = []
+  let liveData = []
 
-function updateDeviceData () {
-  return makeRequest()
-    .then(response => {
-      devices = response.body
-      return devices
-    })
+  try {
+    const data = await s3.getObject({
+      Bucket: 'test-tvp-whoami-bucket-1npt44dhbyabk',
+      Key: 'brand-and-model.json'
+    }).promise()
+    testData = JSON.parse(data.Body.toString('utf-8'))
+  } catch (ex) {
+    console.error('error fetching test data', ex)
+  }
+
+  if (process.env.ENVIRONMENT !== 'local') {
+    try {
+      const data = await s3.getObject({
+        Bucket: 'live-tvp-whoami-bucket-16yjbiw80xn5q',
+        Key: 'brand-and-model.json'
+      }).promise()
+      liveData = JSON.parse(data.Body.toString('utf-8'))
+    } catch (ex) {
+      console.error('error fetching live data', ex)
+    }
+  }
+
+  return {
+    test: testData,
+    live: liveData
+  }
 }
 
 function fetch () {


### PR DESCRIPTION
This PR updates matterhorn to fetch `tvp-whoami` data from the new location. It still follows the old pattern of fetching and updating the data asychronously.

By default it will use the live bucket, unless you are running the service locally or you pass ?testMode=true as a query parameter