### PR TITLE
get certs from secrets manager

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,13 +5,17 @@ env:
     "GITHUB_KEY": "/CodeBuild/Github-SSH-Key"
     "GITHUB_HOST_KEY": "/CodeBuild/Github-Host-Key"
     "GITHUB_API_TOKEN": "/CodeBuild/GitHub/AccessToken"
-    "CLIENT_CERT": "/CodeBuild/BBC-Client-Cert"
-    "CLIENT_KEY": "/CodeBuild/BBC-Client-Key"
-    "CA_CERT": "/CodeBuild/BBC-CA-Cert"
+secrets-manager:
+    CLIENT_CERT_ENCODED: /CodeBuild/Certs/BBC_Production_Services_Client:Certificate
+    CLIENT_KEY_ENCODED: /CodeBuild/Certs/BBC_Production_Services_Client:PrivateKey
+    CA_CERT_ENCODED: /CodeBuild/Certs/Cloud_Services_Root_Trust:Certificate
 
 phases:
   install:
     commands:
+      - export CLIENT_CERT=$(echo "$CLIENT_CERT_ENCODED" | base64 --decode)
+      - export CLIENT_KEY=$(echo "$CLIENT_KEY_ENCODED" | base64 --decode)
+      - export CA_CERT=$(echo "$CA_CERT_ENCODED" | base64 --decode)
       - configure_github
       - configure_certs
       - load_node


### PR DESCRIPTION
The build job for Matterhorn has been [failing for awhile](https://ci.itv.tools.bbc.co.uk/job/launch/job/matterhorn/job/build/) due to a cert issue. A similar issue blocked tap-launcher. This PR applies the [tap-launcher fix](https://github.com/bbc/tap-launcher/commit/e30301a0a15987c1c91628e8139b34f804fd8171) to matterhorn i.e. certs are retrieved from secrets manager instead of the image.