### PR TITLE
Increase jenkins deploy timeout

### DIFF
--- a/ci/deploy-pipeline.groovy
+++ b/ci/deploy-pipeline.groovy
@@ -9,7 +9,7 @@ pipeline {
     nodejs 'LTS'
   }
   options {
-    timeout(time: 15, unit: 'MINUTES')
+    timeout(time: 25, unit: 'MINUTES')
     buildDiscarder(logRotator(numToKeepStr: '20'))
   }
   stages {


### PR DESCRIPTION
Context:
Currently the deploy jenkins job times out. This has been occurring for a while: https://ci.itv.tools.bbc.co.uk/job/launch/job/matterhorn/job/deploy/

The longer time appears reasonable as it's recycling a lot of ec2 instances. 